### PR TITLE
Add missing DB family mapping for Postgres version 9.6.12

### DIFF
--- a/templates/aurora_postgres.template.yaml
+++ b/templates/aurora_postgres.template.yaml
@@ -86,6 +86,8 @@ Mappings:
       "family": "aurora-postgresql9.6"
     "9.6.11": 
       "family": "aurora-postgresql9.6"
+    "9.6.12":
+      "family": "aurora-postgresql9.6"
     "10.5":
       "family": "aurora-postgresql10"
     "10.6":


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
