### PR TITLE
Amazon Aurora MySQL template

### DIFF
--- a/templates/aurora_mysql-master.template.yaml
+++ b/templates/aurora_mysql-master.template.yaml
@@ -262,14 +262,14 @@ Parameters:
   DBMasterUsername: 
     AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
     ConstraintDescription: "Must begin with a letter and contain only alphanumeric characters."
-    Default: pgadmin
+    Default: msadmin
     Description: "The database admin account username."
     MaxLength: "16"
     MinLength: "1"
     Type: String
   DBPort:
-    Default: 5432
-    Description: "The port the instance will listen for connections on."
+    Default: 3306
+    Description: "The port the instance will listen for connections on. Serverless engine mode supports port 3306."
     Type: Number
     ConstraintDescription: 'Must be in the range [1115-65535].'
     MinValue: 1150
@@ -283,7 +283,7 @@ Parameters:
     Type: String
   DBName: 
     AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
-    Default: 'AuroraPostgresDB'
+    Default: 'AuroraMySQLDB'
     Description: "Name of the Amazon Aurora database."
     MaxLength: "64"
     MinLength: "5"
@@ -337,6 +337,45 @@ Parameters:
       - fips
       - other
       - ''
+  ServerlessMinCapacityUnit:
+    Description: The minimum capacity for an Aurora DB cluster in serverless DB engine mode. The minimum capacity must be less than or equal to the maximum capacity.
+    Type: String
+    Default: '2'
+    AllowedValues:
+    - '2'
+    - '4'
+    - '8'
+    - '16'
+    - '32'
+    - '64'
+    - '128'
+    - '256'
+  ServerlessMaxCapacityUnit:
+    Description: The maximum capacity for an Aurora DB cluster in serverless DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity.
+    Type: String
+    Default: '64'
+    AllowedValues:
+    - '2'
+    - '4'
+    - '8'
+    - '16'
+    - '32'
+    - '64'
+    - '128'
+    - '256'    
+  ServerlessAutoPause:
+    Description: Specifies whether to allow or disallow automatic pause for an Aurora DB cluster in serverless DB engine mode. A DB cluster can be paused only when its idle (it has no connections).
+    Type: String
+    Default: 'false'
+    AllowedValues:
+    - 'true'
+    - 'false'
+  ServerlessSecondsUntilAutoPause:
+    Description: The time, in seconds, before an Aurora DB cluster in serverless mode is auto paused. Min = 300, Max = 86400 (24hrs)
+    Type: Number
+    Default: 300
+    MaxValue: 86400
+    MinValue: 300
 Conditions:
   GovCloudCondition: !Equals 
     - !Ref 'AWS::Region'
@@ -370,7 +409,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub 
-        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/aurora_postgres.template.yaml
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/aurora_mysql.template.yaml
         - QSS3Region: !If [GovCloudCondition , s3-us-gov-west-1 , s3]
       Parameters:
         Subnet1ID:

--- a/templates/aurora_mysql-master.template.yaml
+++ b/templates/aurora_mysql-master.template.yaml
@@ -1,0 +1,429 @@
+Description: "AWS VPC + Aurora MySql, Do Not Remove Apache License Version 2.0 (qs-) Jun,15,2019"
+Metadata:
+  LICENSE: Apache License Version 2.0
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: Network configuration
+      Parameters:
+      - KeyPairName
+      - AvailabilityZones
+      - VPCCIDR
+      - PrivateSubnet1CIDR
+      - PrivateSubnet2CIDR
+      - PublicSubnet1CIDR
+      - PublicSubnet2CIDR
+    - Label:
+        default: Linux bastion configuration
+      Parameters:
+       - EnableBastion
+       - RemoteAccessCIDR
+    - Label:
+        default: Database configuration
+      Parameters:
+      - DBName
+      - DBAutoMinorVersionUpgrade
+      - DBBackupRetentionPeriod
+      - DBEngineVersion
+      - DBEngineMode
+      - DBInstanceClass
+      - DBMasterUsername
+      - DBMasterUserPassword
+      - DBPort
+      - DBAllocatedStorageEncrypted
+      - DBMultiAZ
+      - NotificationList
+    - Label:
+        default: Severless 
+      Parameters:                  
+        - ServerlessMinCapacityUnit                                
+        - ServerlessMaxCapacityUnit
+        - ServerlessAutoPause
+        - ServerlessSecondsUntilAutoPause
+    - Label:
+        default: Database tags (optional)
+      Parameters:
+      - EnvironmentStage
+      - Application
+      - ApplicationVersion
+      - ProjectCostCenter
+      - Confidentiality
+      - Compliance
+    - Label:
+        default: Quick Start configuration
+      Parameters:
+      - QSS3BucketName
+      - QSS3KeyPrefix
+    ParameterLabels:
+      AvailabilityZones:
+        default: Availability Zones
+      DBEngineVersion:
+        default: Database Engine Version
+      DBEngineMode:
+        default: Database Engine Mode      
+      DBName:
+        default: Database name
+      DBAllocatedStorageEncrypted:
+        default: Database encryption enabled
+      DBAutoMinorVersionUpgrade:
+        default: Database auto minor version upgrade
+      DBBackupRetentionPeriod:
+        default: Database backup retention period
+      DBInstanceClass:
+        default: Database instance class
+      DBMasterUsername:
+        default: Database master username
+      DBMasterUserPassword:
+        default: Database master password
+      DBPort:
+        default: Database port
+      DBMultiAZ:
+        default: Multi-AZ deployment
+      EnableBastion:
+        default: Create bastion stack
+      PrivateSubnet1CIDR:
+        default: Private subnet 1 CIDR
+      PrivateSubnet2CIDR:
+        default: Private subnet 2 CIDR
+      PublicSubnet1CIDR:
+        default: Public subnet 1 CIDR
+      PublicSubnet2CIDR:
+        default: Public subnet 2 CIDR
+      QSS3BucketName:
+        default: Quick Start S3 bucket name
+      QSS3KeyPrefix:
+        default: Quick Start S3 key prefix
+      VPCCIDR:
+        default: VPC CIDR
+      NotificationList:
+        default: SNS notification email
+      EnvironmentStage:
+        default: Environment stage
+      Application:
+        default: Application name
+      ApplicationVersion:
+        default: Application version
+      Compliance:
+        default: Compliance classifier
+      Confidentiality:
+        default: Confidentiality classifier
+      ProjectCostCenter:
+        default: Project cost center
+      KeyPairName:
+        default: Key Name
+      RemoteAccessCIDR:
+        default: Permitted IP range
+      ServerlessMinCapacityUnit:
+        default: Minimum Aurora capacity unit
+      ServerlessMaxCapacityUnit:
+        default: Maximum Aurora capacity unit
+      ServerlessAutoPause:
+        default: Pause compute capacity
+      ServerlessSecondsUntilAutoPause:
+        default: Pause after time of inactivity
+Parameters:
+  AvailabilityZones:
+   Description: >-
+      List of Availability Zones to use for the subnets in the VPC. Only two
+      Availability Zones are used for this deployment, and the logical order of
+      your selections is preserved.
+   Type: 'List<AWS::EC2::AvailabilityZone::Name>'
+  KeyPairName:
+    ConstraintDescription: "Name of an existing EC2 key pair."
+    Description: Name of an existing public/private key pair, for connecting to your instance.
+    Type: "AWS::EC2::KeyPair::KeyName"
+  PrivateSubnet1CIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.0.0/19
+    Description: CIDR block for private subnet 1 located in Availability Zone 1.
+    Type: String
+  PrivateSubnet2CIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.32.0/19
+    Description: CIDR block for private subnet 2 located in Availability Zone 2.
+    Type: String
+  PublicSubnet1CIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.128.0/20
+    Description: CIDR block for the public subnet 1 located in Availability Zone 1.
+    Type: String
+  PublicSubnet2CIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.144.0/20
+    Description: CIDR block for the public subnet 2 located in Availability Zone 2.
+    Type: String
+  RemoteAccessCIDR:
+    AllowedPattern: "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$"
+    ConstraintDescription: "CIDR block parameter must be in the form x.x.x.x/x"
+    Description: "Allowed CIDR block for external SSH access."
+    Type: String
+  VPCCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.0.0/16
+    Description: CIDR block for the VPC.
+    Type: String
+  QSS3BucketName:
+    AllowedPattern: "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$"
+    ConstraintDescription: "Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)."
+    Default: aws-quickstart
+    Description: "S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)."
+    Type: String
+  QSS3KeyPrefix:
+    AllowedPattern: "^[0-9a-zA-Z-/]*$"
+    ConstraintDescription: "Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)."
+    Default: quickstart-amazon-aurora/
+    Description: "S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)."
+    Type: String
+  EnableBastion: 
+    AllowedValues: 
+      - "true"
+      - "false"
+    Default: "true"
+    Description: "If true, a bastion stack will be created."
+    Type: String
+  DBAllocatedStorageEncrypted:
+    Default: true
+    AllowedValues:
+      - true
+      - false
+    Description: Whether or not to encrypt the database.
+    Type: String
+  DBAutoMinorVersionUpgrade: 
+    AllowedValues: 
+      - "true"
+      - "false"
+    Default: "false"
+    Description: "Select true to set up auto minor version upgrade."
+    Type: String
+  DBBackupRetentionPeriod: 
+    Default: "35"
+    Description: "The number of days for which automatic database snapshots are retained."
+    Type: String
+  DBEngineVersion:
+    Description: Select Database Engine Version
+    Type: String
+    Default: 'Aurora-MySQL5.6.10a'
+    AllowedValues:    
+    - 'Aurora-MySQL5.6.10a'
+    - 'Aurora-MySQL5.6-1.19.0'
+    - 'Aurora-MySQL5.6-1.19.1'
+    - 'Aurora-MySQL5.6-1.19.2'    
+    - 'Aurora-MySQL5.7.12'
+    - 'Aurora-MySQL5.7-2.03.2'
+    - 'Aurora-MySQL5.7-2.03.3'
+    - 'Aurora-MySQL5.7-2.03.4'
+    - 'Aurora-MySQL5.7-2.03.4.2'
+    - 'Aurora-MySQL5.7-2.04.0'
+    - 'Aurora-MySQL5.7-2.04.1'
+    - 'Aurora-MySQL5.7-2.04.1.2' 
+  DBEngineMode:
+    Description: The engine mode of the cluster. Serverless available for Aurora-MySQL5.6.10a. Parallel Query available for Aurora MySQL5.6-x.
+    Type: String
+    Default: 'provisioned'
+    AllowedValues:
+    - 'provisioned'
+    - 'parallelquery'
+    - 'serverless'
+  DBInstanceClass: 
+    AllowedValues: 
+    - db.r5.12xlarge
+    - db.r5.4xlarge
+    - db.r5.2xlarge
+    - db.r5.xlarge
+    - db.r5.large
+    - db.r4.16xlarge
+    - db.r4.8xlarge
+    - db.r4.4xlarge
+    - db.r4.2xlarge
+    - db.r4.xlarge
+    - db.r4.large
+    - db.r3.8xlarge
+    - db.r3.4xlarge
+    - db.r3.2xlarge
+    - db.r3.xlarge
+    - db.r3.large
+    ConstraintDescription: "Must select a valid database instance type."
+    Default: db.r4.large
+    Description: "The name of the compute and memory capacity class of the database instance."
+    Type: String
+  DBMasterUserPassword: 
+    AllowedPattern: "(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*"
+    ConstraintDescription: "Min 8 chars."
+    Description: "The database admin account password."
+    MaxLength: "64"
+    MinLength: "8"
+    NoEcho: "True"
+    Type: String
+  DBMasterUsername: 
+    AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
+    ConstraintDescription: "Must begin with a letter and contain only alphanumeric characters."
+    Default: pgadmin
+    Description: "The database admin account username."
+    MaxLength: "16"
+    MinLength: "1"
+    Type: String
+  DBPort:
+    Default: 5432
+    Description: "The port the instance will listen for connections on."
+    Type: Number
+    ConstraintDescription: 'Must be in the range [1115-65535].'
+    MinValue: 1150
+    MaxValue: 65535
+  DBMultiAZ: 
+    AllowedValues: 
+      - "true"
+      - "false"
+    Default: "true"
+    Description: "Specifies if the database instance is a multiple Availability Zone deployment."
+    Type: String
+  DBName: 
+    AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
+    Default: 'AuroraPostgresDB'
+    Description: "Name of the Amazon Aurora database."
+    MaxLength: "64"
+    MinLength: "5"
+    Type: String
+  NotificationList:
+    Type: String
+    Default: 'db-ops@domain.com'
+    Description: The Email notification is used to configure a SNS topic for sending cloudwatch alarm and RDS Event notifications
+    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
+    ConstraintDescription: provide a valid email address.
+  EnvironmentStage:
+    Type: String
+    Description: Designates the environment stage of the associated AWS resource. (Optional)
+    AllowedValues:
+      - dev
+      - test
+      - pre-prod
+      - prod
+      - none
+    Default: none
+  Application:
+    Type: String
+    Default: ''
+    Description: Designates the application of the associated AWS resource. (Optional)
+  ApplicationVersion:
+    Type: String
+    Description: Designates the specific version of the application. (Optional)
+    Default: ''
+  ProjectCostCenter:
+    Type: String
+    Default: ''
+    Description: Designates the cost center associated with the project of the given AWS resource. (Optional)
+  Confidentiality:
+    Type: String
+    Default: ''
+    Description: Designates the confidentiality classification of the data that is associated with the resource. (Optional)
+    AllowedValues:
+      - public
+      - private
+      - confidential
+      - pii/phi
+      - none
+      - ''
+  Compliance:
+    Type: String
+    Default: ''
+    Description: Designates the compliance level for the AWS resource. (Optional)
+    AllowedValues:
+      - hipaa
+      - sox
+      - fips
+      - other
+      - ''
+Conditions:
+  GovCloudCondition: !Equals 
+    - !Ref 'AWS::Region'
+    - us-gov-west-1
+  EnableBastionAccess: !Equals
+    - !Ref EnableBastion
+    - "true"
+Resources:
+  VPCStack:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      TemplateURL: !Sub
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template
+        - QSS3Region:
+            Fn::If:
+            - GovCloudCondition
+            - s3-us-gov-west-1
+            - s3
+      Parameters:
+        AvailabilityZones: !Join 
+          - ','
+          - !Ref AvailabilityZones
+        KeyPairName: !Ref KeyPairName
+        NumberOfAZs: '2'
+        PrivateSubnet1ACIDR: !Ref PrivateSubnet1CIDR
+        PrivateSubnet2ACIDR: !Ref PrivateSubnet2CIDR
+        PublicSubnet1CIDR: !Ref PublicSubnet1CIDR
+        PublicSubnet2CIDR: !Ref PublicSubnet2CIDR
+        VPCCIDR: !Ref VPCCIDR
+  AuroraStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/aurora_postgres.template.yaml
+        - QSS3Region: !If [GovCloudCondition , s3-us-gov-west-1 , s3]
+      Parameters:
+        Subnet1ID:
+          Fn::GetAtt:
+          - VPCStack
+          - Outputs.PrivateSubnet1AID
+        Subnet2ID:
+          Fn::GetAtt:
+          - VPCStack
+          - Outputs.PrivateSubnet2AID
+        VPCID:
+          Fn::GetAtt:
+          - VPCStack
+          - Outputs.VPCID
+        DBName: !Ref DBName
+        DBAutoMinorVersionUpgrade: !Ref DBAutoMinorVersionUpgrade
+        DBAllocatedStorageEncrypted: !Ref DBAllocatedStorageEncrypted
+        DBBackupRetentionPeriod: !Ref DBBackupRetentionPeriod
+        DBEngineVersion: !Ref DBEngineVersion
+        DBEngineMode: !Ref DBEngineMode
+        DBInstanceClass: !Ref DBInstanceClass
+        DBMasterUsername: !Ref DBMasterUsername
+        DBMasterUserPassword: !Ref DBMasterUserPassword
+        DBPort: !Ref DBPort
+        DBMultiAZ: !Ref DBMultiAZ
+        DBAccessCIDR: !Ref VPCCIDR
+        NotificationList: !Ref NotificationList
+        EnvironmentStage: !Ref EnvironmentStage
+        Application: !Ref Application
+        ApplicationVersion: !Ref ApplicationVersion
+        ProjectCostCenter: !Ref ProjectCostCenter
+        Confidentiality: !Ref Confidentiality
+        Compliance: !Ref Compliance
+        ServerlessMinCapacityUnit: !Ref ServerlessMinCapacityUnit
+        ServerlessMaxCapacityUnit: !Ref ServerlessMaxCapacityUnit
+        ServerlessAutoPause: !Ref ServerlessAutoPause
+        ServerlessSecondsUntilAutoPause: !Ref ServerlessSecondsUntilAutoPause
+  BastionStack:
+    Condition: EnableBastionAccess
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      TemplateURL: !Sub 
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-linux-bastion/templates/linux-bastion.template
+        - QSS3Region: !If [GovCloudCondition , s3-us-gov-west-1 , s3]
+      Parameters:
+        KeyPairName: !Ref KeyPairName
+        PublicSubnet1ID: !GetAtt 
+          - VPCStack
+          - Outputs.PublicSubnet1ID
+        PublicSubnet2ID: !GetAtt 
+          - VPCStack
+          - Outputs.PublicSubnet2ID
+        RemoteAccessCIDR: !Ref RemoteAccessCIDR
+        VPCID: !GetAtt 
+          - VPCStack
+          - Outputs.VPCID

--- a/templates/aurora_mysql.template.yaml
+++ b/templates/aurora_mysql.template.yaml
@@ -1,0 +1,890 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: "AWS Aurora MySql, Do Not Remove Apache License Version 2.0 (qs-) Jun,15,2019"
+Metadata:
+  LICENSE: Apache License Version 2.0
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: Network configuration
+      Parameters:
+      - VPCID
+      - Subnet1ID
+      - Subnet2ID
+      - CustomDBSecurityGroup
+    - Label:
+        default: Database configuration
+      Parameters:
+      - DBName
+      - DBAutoMinorVersionUpgrade
+      - DBBackupRetentionPeriod
+      - DBEngineVersion
+      - DBEngineMode      
+      - DBInstanceClass
+      - DBMasterUsername
+      - DBMasterUserPassword
+      - DBPort
+      - DBAccessCIDR
+      - DBMultiAZ
+      - DBAllocatedStorageEncrypted
+      - NotificationList
+    - Label:
+        default: Severless 
+      Parameters:                  
+        - ServerlessMinCapacityUnit                                
+        - ServerlessMaxCapacityUnit
+        - ServerlessAutoPause
+        - ServerlessSecondsUntilAutoPause
+    - Label:
+        default: Database tags (optional)
+      Parameters:
+      - EnvironmentStage
+      - Application
+      - ApplicationVersion
+      - ProjectCostCenter
+      - Confidentiality
+      - Compliance
+    ParameterLabels:
+      DBName:
+        default: Database name
+      DBEngineVersion:
+        default: Database Engine Version
+      DBEngineMode:
+        default: Database Engine Mode      
+      DBAllocatedStorageEncrypted:
+        default: Database encryption enabled
+      DBAutoMinorVersionUpgrade:
+        default: Database auto minor version upgrade
+      DBBackupRetentionPeriod:
+        default: Database backup retention period
+      DBInstanceClass:
+        default: Database instance class
+      DBMasterUsername:
+        default: Database master username
+      DBMasterUserPassword:
+        default: Database master password
+      DBPort:
+        default: Database port
+      DBAccessCIDR:
+        default: Database connection CIDR
+      DBMultiAZ:
+        default: Multi-AZ deployment
+      Subnet1ID:
+        default: Private subnet 1 ID
+      Subnet2ID:
+        default: Private subne 2 ID
+      VPCID:
+        default: VPC ID
+      CustomDBSecurityGroup:
+        default: Custom securiy group ID
+      NotificationList:
+        default: SNS notification email
+      EnvironmentStage:
+        default: Environment stage
+      Application:
+        default: Application name
+      ApplicationVersion:
+        default: Application version
+      Compliance:
+        default: Compliance classifier
+      Confidentiality:
+       default: Confidentiality classifier
+      ProjectCostCenter:
+       default: Project cost center
+      ServerlessMinCapacityUnit:
+        default: Minimum Aurora capacity unit
+      ServerlessMaxCapacityUnit:
+        default: Maximum Aurora capacity unit
+      ServerlessAutoPause:
+        default: Pause compute capacity
+      ServerlessSecondsUntilAutoPause:
+        default: Pause after time of inactivity
+Mappings: 
+  DBFamilyMap:  
+    "Aurora-MySQL5.6.10a": 
+      "family" : "aurora5.6" 
+    "Aurora-MySQL5.6-1.19.0": 
+      "family" : "aurora5.6"
+    "Aurora-MySQL5.6-1.19.1": 
+      "family" : "aurora5.6" 
+    "Aurora-MySQL5.6-1.19.2": 
+      "family" : "aurora5.6" 
+    "Aurora-MySQL5.7.12":
+      "family" : "aurora-mysql5.7"
+    "Aurora-MySQL5.7-2.03.2":
+      "family" : "aurora-mysql5.7"
+    "Aurora-MySQL5.7-2.03.3":
+      "family" : "aurora-mysql5.7"
+    "Aurora-MySQL5.7-2.03.4":
+      "family" : "aurora-mysql5.7"
+    "Aurora-MySQL5.7-2.03.4.2":
+      "family" : "aurora-mysql5.7"
+    "Aurora-MySQL5.7-2.04.0":
+      "family" : "aurora-mysql5.7"
+    "Aurora-MySQL5.7-2.04.1":
+      "family" : "aurora-mysql5.7"
+    "Aurora-MySQL5.7-2.04.1.2":
+      "family" : "aurora-mysql5.7"
+  
+  DBEngineVersionMap: 
+    "Aurora-MySQL5.6.10a": 
+      "engineversion" : "5.6.10a"
+    "Aurora-MySQL5.6-1.19.0": 
+      "engineversion" : "5.6.mysql_aurora.1.19.0"
+    "Aurora-MySQL5.6-1.19.1": 
+      "engineversion" : "5.6.mysql_aurora.1.19.1"
+    "Aurora-MySQL5.6-1.19.2": 
+      "engineversion" : "5.6.mysql_aurora.1.19.2"
+    "Aurora-MySQL5.7.12":
+      "engineversion" : "5.7.12"
+    "Aurora-MySQL5.7-2.03.2":
+      "engineversion" : "5.7.mysql_aurora.2.03.2"
+    "Aurora-MySQL5.7-2.03.3":
+      "engineversion" : "5.7.mysql_aurora.2.03.3"
+    "Aurora-MySQL5.7-2.03.4":
+      "engineversion" : "5.7.mysql_aurora.2.03.4"
+    "Aurora-MySQL5.7-2.03.4.2":
+      "engineversion" : "5.7.mysql_aurora.2.03.4.2"
+    "Aurora-MySQL5.7-2.04.0":
+      "engineversion" : "5.7.mysql_aurora.2.04.0"
+    "Aurora-MySQL5.7-2.04.1":
+      "engineversion" : "5.7.mysql_aurora.2.04.1"
+    "Aurora-MySQL5.7-2.04.1.2":
+      "engineversion" : "5.7.mysql_aurora.2.04.1.2"
+
+  DBEngineNameMap:    
+    "Aurora-MySQL5.6.10a": 
+      "enginename" : "aurora"
+    "Aurora-MySQL5.6-1.19.0": 
+      "enginename" : "aurora"
+    "Aurora-MySQL5.6-1.19.1": 
+      "enginename" : "aurora"
+    "Aurora-MySQL5.6-1.19.2": 
+      "enginename" : "aurora"
+    "Aurora-MySQL5.7.12":
+      "enginename" : "aurora-mysql"
+    "Aurora-MySQL5.7-2.03.2":
+      "enginename" : "aurora-mysql"
+    "Aurora-MySQL5.7-2.03.3":
+      "enginename" : "aurora-mysql"
+    "Aurora-MySQL5.7-2.03.4":
+      "enginename" : "aurora-mysql"
+    "Aurora-MySQL5.7-2.03.4.2":
+      "enginename" : "aurora-mysql"
+    "Aurora-MySQL5.7-2.04.0":
+      "enginename" : "aurora-mysql"
+    "Aurora-MySQL5.7-2.04.1":
+      "enginename" : "aurora-mysql"
+    "Aurora-MySQL5.7-2.04.1.2":
+      "enginename" : "aurora-mysql"
+Conditions:
+  IsServerlessEnabled:
+    !Equals
+    - !Ref DBEngineMode
+    - 'serverless'       
+  IsServerlessDisabled:
+    !Equals
+    - !Ref DBEngineMode
+    - 'provisioned'    
+  IsDBMultiAZ:
+    !And
+      - !Equals
+        - !Ref DBMultiAZ
+        - 'true'
+      - !Or  
+        - !Equals 
+          - !Ref DBEngineMode
+          - 'provisioned'
+        - !Equals 
+          - !Ref DBEngineMode
+          - 'parallelquery'
+  DoCreateDatabase:
+    !Not
+      - !Equals
+        - !Ref DBName
+        - ''
+  UseDatabaseEncryption:
+    !Equals
+    - !Ref DBAllocatedStorageEncrypted
+    - true
+  CreateSecurityGroup:
+    !Equals
+    - !Ref CustomDBSecurityGroup
+    - ''  
+Outputs: 
+  DBName: 
+    Description: "Amazon Aurora database name"
+    Value: !Ref DBName
+  RDSEndPointAddress: 
+    Description: "Amazon Aurora endpoint"
+    Value: !Sub ${AuroraDBCluster.Endpoint.Address}
+  RDSEndPointPort: 
+    Description: "Amazon Aurora port"
+    Value: !Sub ${AuroraDBCluster.Endpoint.Port}
+  RDSEndPoints: 
+    Description: "Full Amazon Aurora endpoint"
+    Value: !Sub ${AuroraDBCluster.Endpoint.Address}:${AuroraDBCluster.Endpoint.Port}/${DBName}
+  RDSEncryptionKey:
+    Condition: UseDatabaseEncryption
+    Description: The alias of the encryption key created for RDS
+    Value: !Ref EncryptionKeyAlias
+Parameters: 
+  DBAllocatedStorageEncrypted:
+    Default: true
+    AllowedValues:
+      - true
+      - false
+    Description: Whether or not to encrypt the database.
+    Type: String
+  DBAutoMinorVersionUpgrade: 
+    AllowedValues: 
+      - "true"
+      - "false"
+    Default: "false"
+    Description: "Select true to set up auto minor version upgrade."
+    Type: String
+  DBBackupRetentionPeriod: 
+    Default: "35"
+    Description: "The number of days for which automatic database snapshots are retained."
+    Type: String
+  DBEngineVersion:
+    Description: Select Database Engine Version
+    Type: String
+    Default: 'Aurora-MySQL5.6.10a'
+    AllowedValues:    
+    - 'Aurora-MySQL5.6.10a'
+    - 'Aurora-MySQL5.6-1.19.0'
+    - 'Aurora-MySQL5.6-1.19.1'
+    - 'Aurora-MySQL5.6-1.19.2'    
+    - 'Aurora-MySQL5.7.12'
+    - 'Aurora-MySQL5.7-2.03.2'
+    - 'Aurora-MySQL5.7-2.03.3'
+    - 'Aurora-MySQL5.7-2.03.4'
+    - 'Aurora-MySQL5.7-2.03.4.2'
+    - 'Aurora-MySQL5.7-2.04.0'
+    - 'Aurora-MySQL5.7-2.04.1'
+    - 'Aurora-MySQL5.7-2.04.1.2'  
+  DBEngineMode:
+    Description: The engine mode of the cluster. Serverless available for Aurora-MySQL5.6.10a. Parallel Query available for Aurora MySQL5.6-x.
+    Type: String
+    Default: 'provisioned'
+    AllowedValues:
+    - 'provisioned'
+    - 'parallelquery'
+    - 'serverless'      
+  DBInstanceClass: 
+    AllowedValues: 
+    - db.r5.12xlarge
+    - db.r5.4xlarge
+    - db.r5.2xlarge
+    - db.r5.xlarge
+    - db.r5.large
+    - db.r4.16xlarge
+    - db.r4.8xlarge
+    - db.r4.4xlarge
+    - db.r4.2xlarge
+    - db.r4.xlarge
+    - db.r4.large
+    - db.r3.8xlarge
+    - db.r3.4xlarge
+    - db.r3.2xlarge
+    - db.r3.xlarge
+    - db.r3.large  
+    ConstraintDescription: "Must select a valid database instance type."
+    Default: db.r4.large
+    Description: "The name of the compute and memory capacity class of the database instance."
+    Type: String
+  DBAccessCIDR:
+    AllowedPattern: "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$"
+    ConstraintDescription: "CIDR block parameter must be in the form x.x.x.x/x"
+    Description: "Allowed CIDR block for external access (use VPC CIDR)."
+    Type: String
+    Default: 10.0.0.0/16
+  DBMasterUserPassword: 
+    AllowedPattern: "(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*"
+    ConstraintDescription: "Min 8 chars. Must include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ \" ') symbol"
+    Description: "The database admin account password."
+    MaxLength: "64"
+    MinLength: "8"
+    NoEcho: "True"
+    Type: String
+  DBMasterUsername: 
+    AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
+    ConstraintDescription: "Must begin with a letter and contain only alphanumeric characters."
+    Default: msadmin
+    Description: "The database admin account username."
+    MaxLength: "16"
+    MinLength: "1"
+    Type: String
+  DBPort:
+    Default: 3306
+    Description: "The port the instance will listen for connections on. Serverless engine mode supports port 3306."
+    Type: Number
+    ConstraintDescription: 'Must be in the range [1115-65535].'
+    MinValue: 1150
+    MaxValue: 65535
+  DBMultiAZ: 
+    AllowedValues: 
+      - "true"
+      - "false"
+    Default: "true"
+    Description: "Specifies if the database instance is a multiple Availability Zone deployment."
+    Type: String
+  DBName: 
+    AllowedPattern: "[a-zA-Z0-9]*"
+    Description: "Name of the Amazon Aurora database."
+    MaxLength: "64"
+    MinLength: "0"
+    Default: 'AuroraMySQLDB'
+    Type: String
+  CustomDBSecurityGroup:
+    Description: "ID of the security group (e.g., sg-0234se). One will be created for you if left empty."
+    Type: String
+    Default: ''
+  Subnet1ID:
+    Description: The ID of the private subnet in Availability Zone 1.
+    Type: 'AWS::EC2::Subnet::Id'
+  Subnet2ID:
+    Description: The ID of the private subnet in Availability Zone 2.
+    Type: 'AWS::EC2::Subnet::Id'
+  VPCID: 
+    Description: "ID of the VPC you are deploying Aurora into (e.g., vpc-0343606e)."
+    Type: 'AWS::EC2::VPC::Id'
+    Default: ''
+  NotificationList:
+    Type: String
+    Default: 'db-ops@domain.com'
+    Description: The email notification used to configure an SNS topic for sending CloudWatch alarm and RDS event notifications.
+    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
+    ConstraintDescription: Provide a valid email address.
+  EnvironmentStage:
+    Type: String
+    Description: Designates the environment stage of the associated AWS resource. (Optional)
+    AllowedValues:
+      - dev
+      - test
+      - pre-prod
+      - prod
+      - none
+    Default: none
+  Application:
+    Type: String
+    Default: ''
+    Description: Designates the application of the associated AWS resource. (Optional)
+  ApplicationVersion:
+    Type: String
+    Description: Dsignates the specific version of the application. (Optional)
+    Default: ''
+  ProjectCostCenter:
+    Type: String
+    Default: ''
+    Description: Designates the cost center associated with the project of the given AWS resource. (Optional)
+  Confidentiality:
+    Type: String
+    Default: ''
+    Description: Designates the confidentiality classification of the data that is associated with the resource. (Optional)
+    AllowedValues:
+      - public
+      - private
+      - confidential
+      - pii/phi
+      - ''
+  ServerlessMinCapacityUnit:
+    Description: The minimum capacity for an Aurora DB cluster in serverless DB engine mode. The minimum capacity must be less than or equal to the maximum capacity.
+    Type: String
+    Default: '2'
+    AllowedValues:
+    - '2'
+    - '4'
+    - '8'
+    - '16'
+    - '32'
+    - '64'
+    - '128'
+    - '256'
+  ServerlessMaxCapacityUnit:
+    Description: The maximum capacity for an Aurora DB cluster in serverless DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity.
+    Type: String
+    Default: '64'
+    AllowedValues:
+    - '2'
+    - '4'
+    - '8'
+    - '16'
+    - '32'
+    - '64'
+    - '128'
+    - '256'    
+  ServerlessAutoPause:
+    Description: Specifies whether to allow or disallow automatic pause for an Aurora DB cluster in serverless DB engine mode. A DB cluster can be paused only when its idle (it has no connections).
+    Type: String
+    Default: 'false'
+    AllowedValues:
+    - 'true'
+    - 'false'
+  ServerlessSecondsUntilAutoPause:
+    Description: The time, in seconds, before an Aurora DB cluster in serverless mode is auto paused. Min = 300, Max = 86400 (24hrs)
+    Type: Number
+    Default: 300
+    MaxValue: 86400
+    MinValue: 300
+  Compliance:
+    Type: String
+    Default: ''
+    Description: Designates the compliance level for the AWS resource. (Optional)
+    AllowedValues:
+      - hipaa
+      - sox
+      - fips
+      - other
+      - ''
+Resources:
+  DBSNSTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      Subscription:
+      - Endpoint: !Ref NotificationList
+        Protocol: email
+  EncryptionKey:
+    Condition: UseDatabaseEncryption
+    DeletionPolicy: Retain
+    Type: AWS::KMS::Key
+    Properties:
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: !Ref AWS::StackName
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                - !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: 'kms:*'
+            Resource: '*'
+      Tags:
+        - Key: Name
+          Value: !Ref AWS::StackName
+  EncryptionKeyAlias:
+    Condition: UseDatabaseEncryption
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub "alias/${AWS::StackName}"
+      TargetKeyId: !Ref EncryptionKey
+  AuroraDB1:
+    Condition: IsServerlessDisabled
+    Properties:
+      AutoMinorVersionUpgrade: !Ref DBAutoMinorVersionUpgrade
+      DBClusterIdentifier: !Ref AuroraDBCluster
+      DBInstanceClass: !Ref DBInstanceClass
+      Engine: !FindInMap [DBEngineNameMap, !Ref DBEngineVersion, "enginename"]       
+      DBParameterGroupName: !Ref DBParamGroup
+      PubliclyAccessible: false
+      CopyTagsToSnapshot: true
+      Tags:
+        -
+          Key: Name
+          Value: !Sub AuroraDB-${AWS::StackName}
+        -
+          Key: EnvironmentStage
+          Value: !Ref EnvironmentStage
+        -
+          Key: Application
+          Value: !Ref Application
+        -
+          Key: ApplicationVersion
+          Value: !Ref ApplicationVersion
+        -
+          Key: ProjectCostCenter
+          Value: !Ref ProjectCostCenter
+        -
+          Key: Confidentiality
+          Value: !Ref Confidentiality
+        -
+          Key: Compliance
+          Value: !Ref Compliance    
+    Type: "AWS::RDS::DBInstance"
+  AuroraDB2:
+    Condition: IsDBMultiAZ
+    Properties:
+      AutoMinorVersionUpgrade: !Ref DBAutoMinorVersionUpgrade
+      DBClusterIdentifier: !Ref AuroraDBCluster
+      DBInstanceClass: !Ref DBInstanceClass
+      Engine: !FindInMap [DBEngineNameMap, !Ref DBEngineVersion, "enginename"]       
+      DBParameterGroupName: !Ref DBParamGroup
+      PubliclyAccessible: false
+      CopyTagsToSnapshot: true
+      Tags:
+        -
+          Key: Name
+          Value: !Sub AuroraDB-${AWS::StackName}
+        -
+          Key: EnvironmentStage
+          Value: !Ref EnvironmentStage
+        -
+          Key: Application
+          Value: !Ref Application
+        -
+          Key: ApplicationVersion
+          Value: !Ref ApplicationVersion
+        -
+          Key: ProjectCostCenter
+          Value: !Ref ProjectCostCenter
+        -
+          Key: Confidentiality
+          Value: !Ref Confidentiality
+        -
+          Key: Compliance
+          Value: !Ref Compliance
+    Type: "AWS::RDS::DBInstance"
+  AuroraDB3:
+    Condition: IsDBMultiAZ
+    Properties:
+      AutoMinorVersionUpgrade: !Ref DBAutoMinorVersionUpgrade
+      DBClusterIdentifier: !Ref AuroraDBCluster
+      DBInstanceClass: !Ref DBInstanceClass      
+      Engine: !FindInMap [DBEngineNameMap, !Ref DBEngineVersion, "enginename"] 
+      DBParameterGroupName: !Ref DBParamGroup
+      PubliclyAccessible: false
+      CopyTagsToSnapshot: true
+      Tags:
+        -
+          Key: Name
+          Value: !Sub AuroraDB-${AWS::StackName}
+        -
+          Key: EnvironmentStage
+          Value: !Ref EnvironmentStage
+        -
+          Key: Application
+          Value: !Ref Application
+        -
+          Key: ApplicationVersion
+          Value: !Ref ApplicationVersion
+        -
+          Key: ProjectCostCenter
+          Value: !Ref ProjectCostCenter
+        -
+          Key: Confidentiality
+          Value: !Ref Confidentiality
+        -
+          Key: Compliance
+          Value: !Ref Compliance
+    Type: "AWS::RDS::DBInstance"
+  DBParamGroup:
+    Type: AWS::RDS::DBParameterGroup
+    Properties:
+      Description: !Join [ "- ", [ "Aurora MS Database Instance Parameter Group for Cloudformation Stack ", !Ref DBName ] ]
+      Family: !FindInMap [DBFamilyMap, !Ref DBEngineVersion, "family"] 
+      Parameters:
+        general_log: 0 
+  RDSDBClusterParameterGroup:
+    Type: AWS::RDS::DBClusterParameterGroup
+    Properties:
+      Description: !Join [ "- ", [ "Aurora MS Cluster Parameter Group for  Cloudformation Stack ", !Ref DBName ] ]
+      Family: !FindInMap [DBFamilyMap, !Ref DBEngineVersion, "family"] 
+      Parameters:        
+        time_zone: UTC      
+  AuroraDBCluster: 
+    Type: "AWS::RDS::DBCluster"
+    Properties: 
+      BackupRetentionPeriod: !Ref DBBackupRetentionPeriod
+      DBClusterParameterGroupName: !Ref RDSDBClusterParameterGroup
+      DBSubnetGroupName: !Ref AuroraDBSubnetGroup
+      DatabaseName:
+        !If
+        - DoCreateDatabase
+        - !Ref DBName
+        - !Ref AWS::NoValue
+      Engine:  !FindInMap [DBEngineNameMap, !Ref DBEngineVersion, "enginename"] 
+      EngineVersion: !FindInMap [DBEngineVersionMap, !Ref DBEngineVersion, "engineversion"] 
+      EngineMode: !Ref DBEngineMode
+      ScalingConfiguration:  !If
+        - IsServerlessEnabled
+        - AutoPause: !Ref ServerlessAutoPause
+          MaxCapacity: !Ref ServerlessMaxCapacityUnit
+          MinCapacity: !Ref ServerlessMinCapacityUnit
+          SecondsUntilAutoPause: !Ref ServerlessSecondsUntilAutoPause
+        - !Ref AWS::NoValue
+      KmsKeyId: !If [UseDatabaseEncryption, !GetAtt EncryptionKey.Arn, !Ref 'AWS::NoValue']
+      MasterUserPassword: !Ref DBMasterUserPassword
+      MasterUsername: !Ref DBMasterUsername
+      Port: !Ref DBPort
+      StorageEncrypted: !If [UseDatabaseEncryption, !Ref DBAllocatedStorageEncrypted, !Ref 'AWS::NoValue']
+      Tags: 
+        - 
+          Key: Name
+          Value: !Sub AuroraDB-${AWS::StackName}
+        -
+          Key: EnvironmentStage
+          Value: !Ref EnvironmentStage
+        -
+          Key: Application
+          Value: !Ref Application
+        -
+          Key: ApplicationVersion
+          Value: !Ref ApplicationVersion
+        -
+          Key: ProjectCostCenter
+          Value: !Ref ProjectCostCenter
+        -
+          Key: Confidentiality
+          Value: !Ref Confidentiality
+        -
+          Key: Compliance
+          Value: !Ref Compliance
+      VpcSecurityGroupIds: 
+        !If
+          - CreateSecurityGroup
+          - [!Ref RDSSecurityGroup]
+          - [!Ref CustomDBSecurityGroup]
+    UpdateReplacePolicy: Snapshot
+  AuroraDBSubnetGroup: 
+    Properties: 
+      DBSubnetGroupDescription: "Subnets available for the Amazon Aurora database instance"
+      SubnetIds: 
+       - !Ref Subnet1ID
+       - !Ref Subnet2ID
+    Type: "AWS::RDS::DBSubnetGroup"
+  RDSSecurityGroup:
+    Condition: CreateSecurityGroup
+    Properties: 
+      GroupDescription: "Allow access to database port" 
+      SecurityGroupEgress: 
+        - 
+          CidrIp: 0.0.0.0/0
+          FromPort: -1
+          IpProtocol: '-1'
+          ToPort: -1
+      SecurityGroupIngress: 
+        - 
+          CidrIp: !Ref DBAccessCIDR 
+          FromPort: !Ref DBPort
+          IpProtocol: tcp
+          ToPort: !Ref DBPort
+      VpcId: !Ref VPCID
+      Tags:
+      - Key: Name
+        Value: !Sub RDSSecurityGroup-${AWS::StackName}
+    Type: "AWS::EC2::SecurityGroup"
+  RDSSecurityGroupIngress:
+    Condition: CreateSecurityGroup
+    Properties:
+      GroupId: !GetAtt 'RDSSecurityGroup.GroupId'
+      IpProtocol: '-1'
+      SourceSecurityGroupId: !Ref RDSSecurityGroup
+      Description: 'Self Reference'
+    Type: 'AWS::EC2::SecurityGroupIngress'
+  CPUUtilizationAlarm1:
+    Type: "AWS::CloudWatch::Alarm"
+    Condition: IsServerlessDisabled
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+      - Ref: DBSNSTopic
+      AlarmDescription: 'CPU_Utilization'
+      Dimensions:
+      - Name: DBInstanceIdentifier
+        Value:
+          Ref: AuroraDB1
+      MetricName: CPUUtilization
+      Statistic: Maximum
+      Namespace: 'AWS/RDS'
+      Threshold: 80
+      Unit: Percent
+      ComparisonOperator: 'GreaterThanOrEqualToThreshold'
+      Period: 60
+      EvaluationPeriods: 5
+      TreatMissingData: 'notBreaching'
+  CPUUtilizationAlarm2:
+    Condition: IsDBMultiAZ
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+      - Ref: DBSNSTopic
+      AlarmDescription: 'CPU_Utilization'
+      Dimensions:
+      - Name: DBInstanceIdentifier
+        Value:
+          Ref: AuroraDB2
+      MetricName: CPUUtilization
+      Statistic: Maximum
+      Namespace: 'AWS/RDS'
+      Threshold: 80
+      Unit: Percent
+      ComparisonOperator: 'GreaterThanOrEqualToThreshold'
+      Period: 60
+      EvaluationPeriods: 5
+      TreatMissingData: 'notBreaching'
+  CPUUtilizationAlarm3:
+    Condition: IsDBMultiAZ
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+      - Ref: DBSNSTopic
+      AlarmDescription: 'CPU_Utilization'
+      Dimensions:
+      - Name: DBInstanceIdentifier
+        Value:
+          Ref: AuroraDB3
+      MetricName: CPUUtilization
+      Statistic: Maximum
+      Namespace: 'AWS/RDS'
+      Threshold: 80
+      Unit: Percent
+      ComparisonOperator: 'GreaterThanOrEqualToThreshold'
+      Period: 60
+      EvaluationPeriods: 5
+      TreatMissingData: 'notBreaching'
+  MaxUsedTxIDsAlarm1:
+    Type: "AWS::CloudWatch::Alarm"
+    Condition: IsServerlessDisabled
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+      - Ref: DBSNSTopic
+      AlarmDescription: 'Maximum Used Transaction IDs'
+      Dimensions:
+      - Name: DBInstanceIdentifier
+        Value:
+          Ref: AuroraDB1
+      MetricName: 'MaximumUsedTransactionIDs'
+      Statistic: Average
+      Namespace: 'AWS/RDS'
+      Threshold: 600000000
+      Unit: Count
+      ComparisonOperator: 'GreaterThanOrEqualToThreshold'
+      Period: 60
+      EvaluationPeriods: 5
+      TreatMissingData: 'notBreaching'
+  MaxUsedTxIDsAlarm2:
+    Condition: IsDBMultiAZ
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+      - Ref: DBSNSTopic
+      AlarmDescription: 'Maximum Used Transaction IDs'
+      Dimensions:
+      - Name: DBInstanceIdentifier
+        Value:
+          Ref: AuroraDB2
+      MetricName: 'MaximumUsedTransactionIDs'
+      Statistic: Average
+      Namespace: 'AWS/RDS'
+      Threshold: 600000000
+      Unit: Count
+      ComparisonOperator: 'GreaterThanOrEqualToThreshold'
+      Period: 60
+      EvaluationPeriods: 5
+      TreatMissingData: 'notBreaching'
+  MaxUsedTxIDsAlarm3:
+    Condition: IsDBMultiAZ
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+      - Ref: DBSNSTopic
+      AlarmDescription: 'Maximum Used Transaction IDs'
+      Dimensions:
+      - Name: DBInstanceIdentifier
+        Value:
+          Ref: AuroraDB3
+      MetricName: 'MaximumUsedTransactionIDs'
+      Statistic: Average
+      Namespace: 'AWS/RDS'
+      Threshold: 600000000
+      Unit: Count
+      ComparisonOperator: 'GreaterThanOrEqualToThreshold'
+      Period: 60
+      EvaluationPeriods: 5
+      TreatMissingData: 'notBreaching'
+  FreeLocalStorageAlarm1:
+    Type: "AWS::CloudWatch::Alarm"
+    Condition: IsServerlessDisabled
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+      - Ref: DBSNSTopic
+      AlarmDescription: 'Free Local Storage'
+      Dimensions:
+      - Name: DBInstanceIdentifier
+        Value:
+          Ref: AuroraDB1
+      MetricName: 'FreeLocalStorage'
+      Statistic: Average
+      Namespace: 'AWS/RDS'
+      Threshold: 5368709120
+      Unit: Bytes
+      ComparisonOperator: 'LessThanOrEqualToThreshold'
+      Period: 60
+      EvaluationPeriods: 5
+      TreatMissingData: 'notBreaching'
+  FreeLocalStorageAlarm2:
+    Condition: IsDBMultiAZ
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+      - Ref: DBSNSTopic
+      AlarmDescription: 'Free Local Storage'
+      Dimensions:
+      - Name: DBInstanceIdentifier
+        Value:
+          Ref: AuroraDB2
+      MetricName: 'FreeLocalStorage'
+      Statistic: Average
+      Namespace: 'AWS/RDS'
+      Threshold: 5368709120
+      Unit: Bytes
+      ComparisonOperator: 'LessThanOrEqualToThreshold'
+      Period: 60
+      EvaluationPeriods: 5
+      TreatMissingData: 'notBreaching'
+  FreeLocalStorageAlarm3:
+    Condition: IsDBMultiAZ
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+      - Ref: DBSNSTopic
+      AlarmDescription: 'Free Local Storage'
+      Dimensions:
+      - Name: DBInstanceIdentifier
+        Value:
+          Ref: AuroraDB3
+      MetricName: 'FreeLocalStorage'
+      Statistic: Average
+      Namespace: 'AWS/RDS'
+      Threshold: 5368709120
+      Unit: Bytes
+      ComparisonOperator: 'LessThanOrEqualToThreshold'
+      Period: 60
+      EvaluationPeriods: 5
+      TreatMissingData: 'notBreaching'
+  DatabaseClusterEventSubscription:
+    Type: 'AWS::RDS::EventSubscription'
+    Properties:
+      EventCategories:
+      - failover
+      - failure
+      - notification
+      SnsTopicArn: !Ref DBSNSTopic
+      SourceIds: [!Ref AuroraDBCluster]
+      SourceType: 'db-cluster'
+  DatabaseInstanceEventSubscription:
+    Type: 'AWS::RDS::EventSubscription'
+    Properties:
+      EventCategories:
+      - availability
+      - configuration change
+      - deletion
+      - failover
+      - failure
+      - maintenance
+      - notification
+      - recovery
+      SnsTopicArn: !Ref DBSNSTopic
+      SourceIds:             
+      - !If [IsServerlessDisabled, !Ref AuroraDB1, !Ref "AWS::NoValue"]
+      - !If [IsDBMultiAZ, !Ref AuroraDB2, !Ref "AWS::NoValue"]
+      - !If [IsDBMultiAZ, !Ref AuroraDB3, !Ref "AWS::NoValue"]
+      SourceType: 'db-instance'


### PR DESCRIPTION
*Description of changes:*

Aurora MySQL support, including options to configure Serverless and Parallel Query (exclusive to Aurora MySQL5.6).

In regards to testing (us-east-2):
Aurora-MySQL5.6-1.19.0 | provisioned | multiAZ -> PASS
Aurora-MySQL5.7.12 | provisioned | 1AZ -> PASS
Aurora-MySQL5.6-1.19.0 | provisioned | 1AZ -> PASS
Aurora-MySQL5.6-1.19.0 | ParellelQuery | multiAZ -> PASS
Aurora-MySQL5.6-1.19.0 | ParellelQuery | 1AZ -> PASS
Aurora-MySQL5.6.10a | serverless -> PASS

Note conditionals added into template. Required for Serverless, where MultiAZ is not required, nor should RDS instances be created, only Cluster configuration is needed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
